### PR TITLE
Add organizational sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+# Flask Application w/ Frontend
+
+## Overview
+
+This demo walks you through running a front end for your Flask application, as well as modifying it to include some new functionality.
+
+### Learning Objectives
+- Run a Flask front end
+- Practice front-end development skills (HTML, JS)
+- Understand how the source code connects to what is rendered in the browser
+
+### Prior Knowledge:
+- HTTP requests and REST APIs
+- Basic knowledge of HTML and JavaScript
+
+### Time Estimate: 15-20 minutes
+
+## Prerequisites
+You should have MongoDB installed and running
 
 ## How to run
 
@@ -12,6 +31,7 @@ pip install -r requirements.txt
 ### Run the back end
 
 ```
+cd server
 python app.py
 ```
 
@@ -21,6 +41,7 @@ In a **different terminal**, navigate to the project's directory and run
 
 ```
 source .venv/bin/activate
+cd frontend
 python frontend.py
 ```
 


### PR DESCRIPTION
I wrote a short description here, please let me know whether this style is sufficient or it should be more detailed. 

The time estimate for this one is a bit longer, since it involves actually writing code as part of the exercise, and some students will have zero experience writing HTML or JS. I also added in the edits to the running instructions as seen in the `flask-frontend-testing` repo.

For the most part I think the repos work better as standalone demos/exercises, since it helps keep the lesson focused and gives students a fresh canvas to work with, but in the case of `flask-frontend` and `flask-frontend-testing` it could make sense to merge them since they are so similar. I made a branch to this repo incorporating the testing content, which could either be merged in entirely or left as a side branch to use in the relevant lecture.